### PR TITLE
removed `t` from playground coins

### DIFF
--- a/src/module.playground/setup/setup.dex.ts
+++ b/src/module.playground/setup/setup.dex.ts
@@ -16,64 +16,64 @@ export class SetupDex extends PlaygroundSetup<PoolPairSetup> {
     // MAX_SYMBOL_LENGTH = 8
     return [
       {
-        symbol: 'DFI-tBTC',
+        symbol: 'DFI-BTC',
         create: {
           tokenA: 'DFI',
-          tokenB: 'tBTC',
+          tokenB: 'BTC',
           commission: 0,
           status: true,
           ownerAddress: PlaygroundSetup.address
         },
         add: {
-          '*': ['1000@DFI', '1000@tBTC']
+          '*': ['1000@DFI', '1000@BTC']
         },
         utxoToAccount: {
           [PlaygroundSetup.address]: '1000@0'
         }
       },
       {
-        symbol: 'DFI-tETH',
+        symbol: 'DFI-ETH',
         create: {
           tokenA: 'DFI',
-          tokenB: 'tETH',
+          tokenB: 'ETH',
           commission: 0,
           status: true,
           ownerAddress: PlaygroundSetup.address
         },
         add: {
-          '*': ['1000@DFI', '100000@tETH']
+          '*': ['1000@DFI', '100000@ETH']
         },
         utxoToAccount: {
           [PlaygroundSetup.address]: '1000@0'
         }
       },
       {
-        symbol: 'DFI-tUSD',
+        symbol: 'DFI-USDT',
         create: {
           tokenA: 'DFI',
-          tokenB: 'tUSD',
+          tokenB: 'USDT',
           commission: 0,
           status: true,
           ownerAddress: PlaygroundSetup.address
         },
         add: {
-          '*': ['1000@DFI', '10000000@tUSD']
+          '*': ['1000@DFI', '10000000@USDT']
         },
         utxoToAccount: {
           [PlaygroundSetup.address]: '1000@0'
         }
       },
       {
-        symbol: 'DFI-tLTC',
+        symbol: 'DFI-LTC',
         create: {
           tokenA: 'DFI',
-          tokenB: 'tLTC',
+          tokenB: 'LTC',
           commission: 0,
           status: true,
           ownerAddress: PlaygroundSetup.address
         },
         add: {
-          '*': ['100@DFI', '10000@tLTC']
+          '*': ['100@DFI', '10000@LTC']
         },
         utxoToAccount: {
           [PlaygroundSetup.address]: '100@0'

--- a/src/module.playground/setup/setup.token.ts
+++ b/src/module.playground/setup/setup.token.ts
@@ -13,7 +13,7 @@ export class SetupToken extends PlaygroundSetup<TokenSetup> {
     return [
       {
         create: {
-          symbol: 'tBTC',
+          symbol: 'BTC',
           name: 'Playground BTC',
           isDAT: true,
           mintable: true,
@@ -24,7 +24,7 @@ export class SetupToken extends PlaygroundSetup<TokenSetup> {
       },
       {
         create: {
-          symbol: 'tETH',
+          symbol: 'ETH',
           name: 'Playground ETH',
           isDAT: true,
           mintable: true,
@@ -35,8 +35,8 @@ export class SetupToken extends PlaygroundSetup<TokenSetup> {
       },
       {
         create: {
-          symbol: 'tUSD',
-          name: 'Playground USD',
+          symbol: 'USDT',
+          name: 'Playground USDT',
           isDAT: true,
           mintable: true,
           tradeable: true,
@@ -46,7 +46,7 @@ export class SetupToken extends PlaygroundSetup<TokenSetup> {
       },
       {
         create: {
-          symbol: 'tLTC',
+          symbol: 'LTC',
           name: 'Playground LTC',
           isDAT: true,
           mintable: true,


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

To make it easier to test and match production instances, removed `t` from coins. `tBTC` -> `BTC`
