### PR TITLE
add curl for docker healthcheck capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:14-alpine3.13
 
+# add curl for docker healthcheck capability
+RUN apk --no-cache add curl
+
 WORKDIR /app
 
 COPY LICENSE ./


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Add curl to allow internal DOCKER HEALTHCHECK, https://docs.docker.com/engine/reference/builder/#healthcheck
Not configured within Dockerfile, should only be configured externally if required.
