### PR TITLE
rename _health to _actuator to allow more features to be added for service controllability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
       - name: Setup docker containers
         run: docker-compose -f __sanity__/docker-compose.yml up -d
 
-      - name: Wait for :3002/_health/probes/liveness
-        run: ./__sanity__/wait-for http://localhost:3001/_health/probes/liveness -t 120
+      - name: Wait for :3002/_actuator/probes/liveness
+        run: ./__sanity__/wait-for http://localhost:3001/_actuator/probes/liveness -t 120
 
-      - name: Wait for :3001/_health/probes/liveness
-        run: ./__sanity__/wait-for http://localhost:3002/_health/probes/liveness -t 120
+      - name: Wait for :3001/_actuator/probes/liveness
+        run: ./__sanity__/wait-for http://localhost:3002/_actuator/probes/liveness -t 120
 
       - name: Wait for :8082/ping
         run: ./__sanity__/wait-for http://localhost:8082/ping -t 120

--- a/src/module.api/_module.ts
+++ b/src/module.api/_module.ts
@@ -1,7 +1,7 @@
 import { APP_INTERCEPTOR } from '@nestjs/core'
 import { Module } from '@nestjs/common'
 import { RpcController } from '@src/module.api/rpc.controller'
-import { HealthController } from '@src/module.api/health.controller'
+import { ActuatorController } from '@src/module.api/actuator.controller'
 import { ExceptionInterceptor } from '@src/module.api/interceptors/exception.interceptor'
 import { ResponseInterceptor } from '@src/module.api/interceptors/response.interceptor'
 import { PlaygroundController } from '@src/module.api/playground.controller'
@@ -11,7 +11,7 @@ import { PlaygroundController } from '@src/module.api/playground.controller'
  */
 @Module({
   controllers: [
-    HealthController,
+    ActuatorController,
     RpcController,
     PlaygroundController
   ],

--- a/src/module.api/actuator.controller.ts
+++ b/src/module.api/actuator.controller.ts
@@ -3,8 +3,8 @@ import { HealthCheck, HealthCheckResult, HealthCheckService } from '@nestjs/term
 import { DeFiDProbeIndicator } from '@src/module.defid/defid.indicator'
 import { PlaygroundProbeIndicator } from '@src/module.playground/playground.indicator'
 
-@Controller('/_health')
-export class HealthController {
+@Controller('/_actuator')
+export class ActuatorController {
   constructor (
     private readonly health: HealthCheckService,
     private readonly defid: DeFiDProbeIndicator,

--- a/src/module.api/actuator.e2e.ts
+++ b/src/module.api/actuator.e2e.ts
@@ -15,11 +15,11 @@ afterAll(async () => {
   await stopTestingApp(container, app)
 })
 
-describe('/_health/probes/liveness', () => {
+describe('/_actuator/probes/liveness', () => {
   it('should wait until liveness', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: '/_health/probes/liveness'
+      url: '/_actuator/probes/liveness'
     })
 
     expect(res.statusCode).toStrictEqual(200)
@@ -46,11 +46,11 @@ describe('/_health/probes/liveness', () => {
   })
 })
 
-describe('/_health/probes/readiness', () => {
+describe('/_actuator/probes/readiness', () => {
   it('should wait until readiness', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: '/_health/probes/readiness'
+      url: '/_actuator/probes/readiness'
     })
 
     expect(res.statusCode).toStrictEqual(200)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Rename `/_health/*` to`/ _actuator/*` to allow more features to be added for service controllability. 
