### PR TITLE
`wallets/tokens/:id/send` to support sending all token id with automatic confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@defichain/jellyfish-api-core": ">=0.36.0",
         "@defichain/jellyfish-api-jsonrpc": ">=0.36.0",
         "@defichain/jellyfish-crypto": ">=0.36.0",
+        "@defichain/jellyfish-testing": ">=0.36.0",
         "@defichain/jellyfish-transaction": ">=0.36.0",
         "@defichain/jellyfish-transaction-builder": ">=0.36.0",
         "@defichain/testcontainers": ">=0.36.0",
@@ -920,6 +921,18 @@
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.36.0.tgz",
       "integrity": "sha512-Uv/gWKUijhZij+rPvyRIJv0PEpy4Hro6YBLzhBTogMbaAE+P9YNZnZCo3t3vqZ7FNOxAel7KXQpI8LgX8VNCtw=="
+    },
+    "node_modules/@defichain/jellyfish-testing": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-testing/-/jellyfish-testing-0.36.0.tgz",
+      "integrity": "sha512-ZSp8ehUcWL3NZuO2fHCq4eR3yP7ITHxQTjOEVpbwONAJpybt40Uk3vnBuqAr0ZfQqt8IIWtWpRLqHwYrZsfQVQ==",
+      "dependencies": {
+        "@defichain/jellyfish-api-jsonrpc": "^0.36.0",
+        "@defichain/jellyfish-crypto": "^0.36.0",
+        "@defichain/jellyfish-network": "^0.36.0",
+        "@defichain/testcontainers": "^0.36.0",
+        "cross-fetch": "^3.1.4"
+      }
     },
     "node_modules/@defichain/jellyfish-transaction": {
       "version": "0.36.0",
@@ -16502,6 +16515,18 @@
       "version": "0.36.0",
       "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.36.0.tgz",
       "integrity": "sha512-Uv/gWKUijhZij+rPvyRIJv0PEpy4Hro6YBLzhBTogMbaAE+P9YNZnZCo3t3vqZ7FNOxAel7KXQpI8LgX8VNCtw=="
+    },
+    "@defichain/jellyfish-testing": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-testing/-/jellyfish-testing-0.36.0.tgz",
+      "integrity": "sha512-ZSp8ehUcWL3NZuO2fHCq4eR3yP7ITHxQTjOEVpbwONAJpybt40Uk3vnBuqAr0ZfQqt8IIWtWpRLqHwYrZsfQVQ==",
+      "requires": {
+        "@defichain/jellyfish-api-jsonrpc": "^0.36.0",
+        "@defichain/jellyfish-crypto": "^0.36.0",
+        "@defichain/jellyfish-network": "^0.36.0",
+        "@defichain/testcontainers": "^0.36.0",
+        "cross-fetch": "^3.1.4"
+      }
     },
     "@defichain/jellyfish-transaction": {
       "version": "0.36.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@defichain/jellyfish-api-core": ">=0.36.0",
     "@defichain/jellyfish-api-jsonrpc": ">=0.36.0",
     "@defichain/jellyfish-crypto": ">=0.36.0",
+    "@defichain/jellyfish-testing": ">=0.36.0",
     "@defichain/jellyfish-transaction": ">=0.36.0",
     "@defichain/jellyfish-transaction-builder": ">=0.36.0",
     "@defichain/testcontainers": ">=0.36.0",

--- a/packages/playground-api-client/__tests__/api/wallet.test.ts
+++ b/packages/playground-api-client/__tests__/api/wallet.test.ts
@@ -43,6 +43,23 @@ it('should get wallet', async () => {
 })
 
 describe('tokens', () => {
+  it('should send utxo to address and wait for automated block confirmation', async () => {
+    const address = await testing.generateAddress()
+
+    const txid = await client.wallet.sendUtxo('19.34153143', address)
+    expect(txid.length).toStrictEqual(64)
+
+    const unspent = await testing.rpc.wallet.listUnspent(1, 999999, {
+      addresses: [address]
+    })
+
+    expect(unspent.length).toStrictEqual(1)
+    expect(unspent[0]).toStrictEqual(expect.objectContaining({
+      amount: '19.34153143',
+      address: 'bcrt1q7ahfyta7m0ylppqv6gs2ghh2fc5ce9r6sjr0c6'
+    }))
+  })
+
   it('should send token 0 to address and wait for automated block confirmation', async () => {
     const address = 'bcrt1qkt7rvkzk8qs7rk54vghrtzcdxfqazscmmp30hk'
 

--- a/packages/playground-api-client/__tests__/api/wallet.test.ts
+++ b/packages/playground-api-client/__tests__/api/wallet.test.ts
@@ -2,6 +2,7 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { StubPlaygroundApiClient } from '../stub.client'
 import { StubService } from '../stub.service'
 import { Testing } from '@defichain/jellyfish-testing'
+import BigNumber from 'bignumber.js'
 
 const container = new MasterNodeRegTestContainer()
 const testing = Testing.create(container)
@@ -54,10 +55,8 @@ describe('tokens', () => {
     })
 
     expect(unspent.length).toStrictEqual(1)
-    expect(unspent[0]).toStrictEqual(expect.objectContaining({
-      amount: '19.34153143',
-      address: 'bcrt1q7ahfyta7m0ylppqv6gs2ghh2fc5ce9r6sjr0c6'
-    }))
+    expect(unspent[0].address).toStrictEqual(address)
+    expect(unspent[0].amount).toStrictEqual(new BigNumber('19.34153143'))
   })
 
   it('should send token 0 to address and wait for automated block confirmation', async () => {

--- a/packages/playground-api-client/src/api/wallet.ts
+++ b/packages/playground-api-client/src/api/wallet.ts
@@ -14,8 +14,20 @@ export class Wallet {
   /**
    * @deprecated use sendToken instead
    */
-  async sendTokenDfiToAddress (data: SendToken): Promise<string> {
+  async sendTokenDfiToAddress (data: SendTo): Promise<string> {
     return await this.sendToken('0', data.amount, data.address)
+  }
+
+  /**
+   * Send utxo to address, this method will wait for confirmation.
+   *
+   * @param {string} amount to send to address
+   * @param {string} address to send to
+   * @return {string} txid
+   */
+  async sendUtxo (amount: string, address: string): Promise<string> {
+    const data: SendTo = { amount, address }
+    return await this.client.requestData('POST', 'wallet/utxo/send', data)
   }
 
   /**
@@ -27,7 +39,7 @@ export class Wallet {
    * @return {string} txid
    */
   async sendToken (tokenId: string, amount: string, address: string): Promise<string> {
-    const data: SendToken = { amount, address }
+    const data: SendTo = { amount, address }
     return await this.client.requestData('POST', `wallet/tokens/${tokenId}/send`, data)
   }
 }
@@ -37,7 +49,7 @@ export interface WalletBalances {
   tokens: Array<{ id: string, balance: number }>
 }
 
-export interface SendToken {
+export interface SendTo {
   amount: string
   address: string
 }

--- a/packages/playground-api-client/src/api/wallet.ts
+++ b/packages/playground-api-client/src/api/wallet.ts
@@ -12,10 +12,23 @@ export class Wallet {
   }
 
   /**
-   * @return {Promise<WalletBalances>} of playground
+   * @deprecated use sendToken instead
    */
-  async sendTokenDfiToAddress (data: TokenDfiToAddress): Promise<string> {
-    return await this.client.requestData('POST', 'wallet/tokens/dfi/sendtoaddress', data)
+  async sendTokenDfiToAddress (data: SendToken): Promise<string> {
+    return await this.sendToken('0', data.amount, data.address)
+  }
+
+  /**
+   * Send token to address, this method will wait for confirmation.
+   *
+   * @param {string} tokenId to send to address
+   * @param {string} amount to send to address
+   * @param {string} address to send to
+   * @return {string} txid
+   */
+  async sendToken (tokenId: string, amount: string, address: string): Promise<string> {
+    const data: SendToken = { amount, address }
+    return await this.client.requestData('POST', `wallet/tokens/${tokenId}/send`, data)
   }
 }
 
@@ -24,7 +37,7 @@ export interface WalletBalances {
   tokens: Array<{ id: string, balance: number }>
 }
 
-export interface TokenDfiToAddress {
+export interface SendToken {
   amount: string
   address: string
 }

--- a/src/module.api/wallet.controller.ts
+++ b/src/module.api/wallet.controller.ts
@@ -57,7 +57,8 @@ export class WalletController {
     const txn = createUtxoToAccountTxn(amount, address)
     const hex = new CTransaction(txn).toHex()
 
-    const { hex: funded } = await this.client.call('fundrawtransaction', [hex, { lockUnspents: true }], 'number')
+    const fundOptions = { lockUnspents: true, changePosition: 1 }
+    const { hex: funded } = await this.client.call('fundrawtransaction', [hex, fundOptions], 'number')
     const { hex: signed } = await this.client.call('signrawtransactionwithwallet', [funded], 'number')
     return await this.client.rawtx.sendRawTransaction(signed)
   }

--- a/src/module.api/wallet.controller.ts
+++ b/src/module.api/wallet.controller.ts
@@ -1,19 +1,9 @@
 import BigNumber from 'bignumber.js'
-import { Body, Controller, Get, Post } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post } from '@nestjs/common'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
-import { TokenDfiToAddress, WalletBalances } from '@playground-api-client/api/wallet'
-import { PlaygroundSetup } from '@src/module.playground/setup/setup'
-import {
-  CTransaction,
-  DeFiTransactionConstants,
-  OP_CODES,
-  Script,
-  Transaction,
-  Vin,
-  Vout
-} from '@defichain/jellyfish-transaction'
+import { SendToken, WalletBalances } from '@playground-api-client/api/wallet'
+import { CTransaction, DeFiTransactionConstants, OP_CODES, Transaction, Vout } from '@defichain/jellyfish-transaction'
 import { DeFiAddress } from '@defichain/jellyfish-address'
-import { UTXO } from '@defichain/jellyfish-api-core/dist/category/wallet'
 
 @Controller('/v0/playground/wallet')
 export class WalletController {
@@ -44,82 +34,36 @@ export class WalletController {
    * @deprecated
    */
   @Post('/tokens/dfi/sendtoaddress')
-  async postDFIFallback (@Body() data: TokenDfiToAddress): Promise<string> {
-    return await this.post(data)
+  async postDFIFallback (@Body() data: SendToken): Promise<string> {
+    return await this.post('0', data)
   }
 
-  @Post('/tokens/0/sendtoaddress')
-  async post (@Body() data: TokenDfiToAddress): Promise<string> {
-    const amount = new BigNumber(data.amount)
-    const script = DeFiAddress.from('regtest', data.address).getScript()
-    const utxos = await this.queryUnspent(amount)
-
-    const transaction = this.createUtxoToAccountTransaction(amount, script, utxos)
-    const hex = new CTransaction(transaction).toHex()
-    const signed = await this.client.rawtx.signRawTransactionWithKey(hex, [PlaygroundSetup.privKey])
-    const txId = await this.client.rawtx.sendRawTransaction(signed.hex, new BigNumber('100'))
-
-    await this.waitConfirmation(txId)
-    return txId
-  }
-
-  /**
-   * Get unspent to spend and locks it.
-   */
-  async queryUnspent (amount: BigNumber): Promise<UTXO[]> {
-    return await this.client.wallet.listUnspent(1, 9999999, {
-      addresses: [PlaygroundSetup.address],
-      includeUnsafe: false,
-      queryOptions: {
-        maximumCount: 100,
-        minimumSumAmount: amount.plus(1).toNumber()
-      }
-    })
-  }
-
-  createUtxoToAccountTransaction (amount: BigNumber, script: Script, utxos: UTXO[]): Transaction {
-    const utxoToAccount: Vout = {
-      value: amount,
-      script: {
-        stack: [
-          OP_CODES.OP_RETURN,
-          OP_CODES.OP_DEFI_TX_UTXOS_TO_ACCOUNT({
-            to: [{
-              script: script,
-              balances: [{ token: 0, amount: amount }]
-            }]
-          })
-        ]
-      },
-      tokenId: 0x00
+  @Post('/tokens/:id/send')
+  async post (@Param('id') tokenId: string, @Body() data: SendToken): Promise<string> {
+    let txid: string
+    if (tokenId === '0') {
+      txid = await this.sendDfiToken(data.amount, data.address)
+    } else {
+      const to = { [data.address]: [`${data.amount}@${tokenId}`] }
+      txid = await this.client.account.sendTokensToAddress({}, to)
     }
 
-    const sum = utxos.reduce((acc, b) => acc.plus(b.amount), new BigNumber(0))
-    const change: Vout = {
-      value: sum.minus(amount).minus(0.00010000), // fixed fee
-      script: DeFiAddress.from('regtest', PlaygroundSetup.address).getScript(),
-      tokenId: 0x00
-    }
-
-    return {
-      version: DeFiTransactionConstants.Version,
-      vin: utxos.map((utxo): Vin => ({
-        index: utxo.vout,
-        script: DeFiAddress.from('regtest', utxo.address).getScript(),
-        sequence: 0xffffffff,
-        txid: utxo.txid
-      })),
-      vout: [
-        utxoToAccount,
-        change
-      ],
-      lockTime: 0x00000000
-    }
+    await this.waitConfirmation(txid)
+    return txid
   }
 
-  async waitConfirmation (txId: string): Promise<void> {
+  async sendDfiToken (amount: string, address: string): Promise<string> {
+    const txn = createUtxoToAccountTxn(amount, address)
+    const hex = new CTransaction(txn).toHex()
+
+    const { hex: funded } = await this.client.call('fundrawtransaction', [hex], 'number')
+    const { hex: signed } = await this.client.call('signrawtransactionwithwallet', [funded], 'number')
+    return await this.client.rawtx.sendRawTransaction(signed)
+  }
+
+  async waitConfirmation (txId: string, timeout: number = 10000): Promise<void> {
     /* eslint-disable no-void */
-    const expiredAt = Date.now() + 10000 // 10 seconds
+    const expiredAt = Date.now() + timeout
 
     return await new Promise((resolve, reject) => {
       const checkCondition = async (): Promise<void> => {
@@ -129,12 +73,40 @@ export class WalletController {
         } else if (expiredAt < Date.now()) {
           reject(new Error('waitConfirmation timeout after 10 seconds'))
         } else {
-          setTimeout(() => void checkCondition(), 500)
+          setTimeout(() => void checkCondition(), 250)
         }
       }
 
       void checkCondition()
     })
     /* eslint-enable no-void */
+  }
+}
+
+function createUtxoToAccountTxn (amount: string, address: string): Transaction {
+  const value = new BigNumber(amount)
+  const script = DeFiAddress.from('regtest', address).getScript()
+
+  const utxoToAccount: Vout = {
+    value: value,
+    script: {
+      stack: [
+        OP_CODES.OP_RETURN,
+        OP_CODES.OP_DEFI_TX_UTXOS_TO_ACCOUNT({
+          to: [{
+            script: script,
+            balances: [{ token: 0, amount: value }]
+          }]
+        })
+      ]
+    },
+    tokenId: 0x00
+  }
+
+  return {
+    version: DeFiTransactionConstants.Version,
+    vin: [],
+    vout: [utxoToAccount],
+    lockTime: 0x00000000
   }
 }

--- a/src/module.playground/_module.ts
+++ b/src/module.playground/_module.ts
@@ -8,10 +8,12 @@ import { PlaygroundBlock } from '@src/module.playground/playground.block'
 import { PlaygroundSetup } from '@src/module.playground/setup/setup'
 import { GenesisKeys } from '@defichain/testcontainers'
 import { SetupMasternode } from '@src/module.playground/setup/setup.masternode'
+import { SetupUtxo } from '@src/module.playground/setup/setup.utxo'
 
 @Global()
 @Module({
   providers: [
+    SetupUtxo,
     SetupToken,
     SetupDex,
     SetupOracle,
@@ -31,12 +33,14 @@ export class PlaygroundModule implements OnApplicationBootstrap {
   constructor (
     private readonly client: JsonRpcClient,
     private readonly indicator: PlaygroundProbeIndicator,
+    utxo: SetupUtxo,
     token: SetupToken,
     dex: SetupDex,
     oracle: SetupOracle,
     masternode: SetupMasternode
   ) {
     this.setups = [
+      utxo,
       token,
       dex,
       oracle,

--- a/src/module.playground/setup/setup.utxo.ts
+++ b/src/module.playground/setup/setup.utxo.ts
@@ -1,0 +1,25 @@
+import { PlaygroundSetup } from '@src/module.playground/setup/setup'
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class SetupUtxo extends PlaygroundSetup<{}> {
+  async create (each: {}): Promise<void> {
+    const count = 50
+
+    const amounts: Record<string, number> = {}
+    for (let i = 0; i < count; i++) {
+      amounts[await this.client.wallet.getNewAddress()] = 10000
+    }
+
+    await this.waitForBalance(10000 * count)
+    await this.client.wallet.sendMany(amounts)
+  }
+
+  async has (each: {}): Promise<boolean> {
+    return false
+  }
+
+  list (): Array<{}> {
+    return [{}]
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

- `wallets/tokens/:id/send` to support sending all tokens with automatic confirmation. This removes the need to specify wait on Cypress tests for tokens.
- this also brings better stability to tokens sending endpoint will lesser failures, verified with a 30x concurrent e2e test
- UTXO is not supported yet

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #135 
Fixed #149 