### PR TITLE
feat(module.playground): add `status:false, tradeEnabled: false` pool pair

### DIFF
--- a/src/module.playground/_module.e2e.ts
+++ b/src/module.playground/_module.e2e.ts
@@ -12,12 +12,12 @@ afterAll(async () => {
 
 it('should have pool pairs setup', async () => {
   const pairs = await testing.client.poolpair.listPoolPairs()
-  expect(Object.values(pairs).length).toBe(11)
+  expect(Object.values(pairs).length).toBe(12)
 })
 
 it('should have tokens setup', async () => {
   const tokens = await testing.client.token.listTokens()
-  expect(Object.values(tokens).length).toBe(27)
+  expect(Object.values(tokens).length).toBe(29)
 })
 
 it('should have oracles setup', async () => {
@@ -52,7 +52,7 @@ it('should have loan tokens', async () => {
 
 it('should have loan collateral tokens', async () => {
   const results = await testing.client.loan.listCollateralTokens()
-  expect(results.length).toBe(11)
+  expect(results.length).toBe(12)
 })
 
 it('should have gov set', async () => {

--- a/src/module.playground/bot/oracle.bot.ts
+++ b/src/module.playground/bot/oracle.bot.ts
@@ -133,6 +133,12 @@ export class OracleBot {
       amount: new BigNumber(0.99),
       change: new BigNumber(0),
       direction: PriceDirection.STABLE
+    },
+    {
+      token: 'OFF',
+      amount: new BigNumber(1),
+      change: new BigNumber(0),
+      direction: PriceDirection.STABLE
     }
   ]
 

--- a/src/module.playground/setup/setup.dex.ts
+++ b/src/module.playground/setup/setup.dex.ts
@@ -155,6 +155,16 @@ export class SetupDex extends PlaygroundSetup<PoolPairSetup> {
           status: true,
           ownerAddress: PlaygroundSetup.address
         }
+      },
+      {
+        symbol: 'OFF-DFI',
+        create: {
+          tokenA: 'OFF',
+          tokenB: 'DFI',
+          commission: 0,
+          status: false,
+          ownerAddress: PlaygroundSetup.address
+        }
       }
     ]
   }
@@ -189,7 +199,7 @@ export class SetupDex extends PlaygroundSetup<PoolPairSetup> {
     const poolPairs = await this.client.poolpair.listPoolPairs()
     const poolPairIds = Object.keys(poolPairs)
 
-    // toFixed(8) due to 1 / 11 = 0.09090909090909091 which is invalid amount on setgov
+    // apply `toFixed(8)` due to 1 / 12 = 0.08333333333333333 which is invalid amount on setgov
     const splits = Number(new BigNumber(1 / poolPairIds.length).toFixed(8))
 
     const lpSplits: any = {}
@@ -197,10 +207,10 @@ export class SetupDex extends PlaygroundSetup<PoolPairSetup> {
       lpSplits[parseInt(k)] = splits
     }
 
-    // to fix: LP_SPLITS: total = 99999999 vs expected 100000000', code: -32600, method: setgov
-    // 0.09090909 * 11 !== 100000000
+    // to fix: LP_SPLITS: total = 99999996 vs expected 100000000', code: -32600, method: setgov
+    // 0.08333333 * 11 !== 100000000
     const lstKey = Object.keys(lpSplits)[0]
-    lpSplits[lstKey] = Number(new BigNumber(lpSplits[lstKey]).plus(0.00000001).toFixed(8))
+    lpSplits[lstKey] = Number(new BigNumber(lpSplits[lstKey]).plus(0.00000004).toFixed(8))
 
     await this.client.masternode.setGov({ LP_SPLITS: lpSplits })
     await this.generate(1)

--- a/src/module.playground/setup/setup.loan.collateral.ts
+++ b/src/module.playground/setup/setup.loan.collateral.ts
@@ -61,6 +61,11 @@ export class SetupLoanCollateral extends PlaygroundSetup<SetCollateralToken> {
         token: 'ZERO',
         fixedIntervalPriceId: 'ZERO/USD',
         factor: new BigNumber('1')
+      },
+      {
+        token: 'OFF',
+        fixedIntervalPriceId: 'OFF/USD',
+        factor: new BigNumber('1')
       }
     ]
   }

--- a/src/module.playground/setup/setup.oracle.ts
+++ b/src/module.playground/setup/setup.oracle.ts
@@ -79,6 +79,10 @@ const FEEDS: OraclePriceFeed[] = [
   {
     token: 'ZERO',
     currency: 'USD'
+  },
+  {
+    token: 'OFF',
+    currency: 'USD'
   }
 ]
 

--- a/src/module.playground/setup/setup.token.ts
+++ b/src/module.playground/setup/setup.token.ts
@@ -120,6 +120,17 @@ export class SetupToken extends PlaygroundSetup<TokenSetup> {
           collateralAddress: PlaygroundSetup.address
         },
         amount: 100000000
+      },
+      {
+        create: {
+          symbol: 'OFF',
+          name: 'Playground OFF',
+          isDAT: true,
+          mintable: true,
+          tradeable: false,
+          collateralAddress: PlaygroundSetup.address
+        },
+        amount: 100000000
       }
     ]
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #419

#### Additional comments?:


checked:
```sh
'28': {
        symbol: 'OFF-DFI',
        name: 'Playground OFF-Default Defi token',
        status: false,
        idTokenA: '11',
        idTokenB: '0',
        reserveA: BigNumber { s: 1, e: 0, c: [Array] },
        reserveB: BigNumber { s: 1, e: 0, c: [Array] },
        commission: BigNumber { s: 1, e: 0, c: [Array] },
        totalLiquidity: BigNumber { s: 1, e: 0, c: [Array] },
        'reserveA/reserveB': '0',
        'reserveB/reserveA': '0',
        tradeEnabled: false,
        ownerAddress: 'mswsMVsyGMj1FzDMbbxw2QW3KvQAv2FKiy',
        blockCommissionA: BigNumber { s: 1, e: 0, c: [Array] },
        blockCommissionB: BigNumber { s: 1, e: 0, c: [Array] },
        rewardPct: BigNumber { s: 1, e: -2, c: [Array] },
        rewardLoanPct: BigNumber { s: 1, e: 0, c: [Array] },
        creationTx: '0a3974aacd602aa6730d994539254ee9f3209fc2fc73fb413e38e1c6492fab9d',
        creationHeight: BigNumber { s: 1, e: 2, c: [Array] }
      }
 ```
